### PR TITLE
Delete event for internal components

### DIFF
--- a/src/main/java/com/ft/methodearticleinternalcomponentsmapper/messaging/MessageBuilder.java
+++ b/src/main/java/com/ft/methodearticleinternalcomponentsmapper/messaging/MessageBuilder.java
@@ -46,7 +46,7 @@ public class MessageBuilder {
         return buildMessage(internalComponents.getUuid(), internalComponents.getPublishReference(), msgBody);
     }
 
-    Message buildMessageForDeletedMethodeContent(String uuid, String publishReference, Date lastModified) {
+    Message buildDeletedInternalComponentsMessage(String uuid, String publishReference, Date lastModified) {
         MessageBody msgBody = new MessageBody(
                 null,
                 contentUriBuilder.build(uuid).toString(),

--- a/src/main/java/com/ft/methodearticleinternalcomponentsmapper/messaging/MessageProducingInternalComponentsMapper.java
+++ b/src/main/java/com/ft/methodearticleinternalcomponentsmapper/messaging/MessageProducingInternalComponentsMapper.java
@@ -2,6 +2,7 @@ package com.ft.methodearticleinternalcomponentsmapper.messaging;
 
 import com.ft.messagequeueproducer.MessageProducer;
 import com.ft.messaging.standards.message.v1.Message;
+import com.ft.methodearticleinternalcomponentsmapper.exception.MethodeArticleHasNoInternalComponentsException;
 import com.ft.methodearticleinternalcomponentsmapper.exception.MethodeArticleMarkedDeletedException;
 import com.ft.methodearticleinternalcomponentsmapper.model.EomFile;
 import com.ft.methodearticleinternalcomponentsmapper.transformation.InternalComponentsMapper;
@@ -36,9 +37,11 @@ public class MessageProducingInternalComponentsMapper {
             message = messageBuilder.buildMessage(
                     internalComponentsMapper.map(methodeContent, transactionId, messageTimestamp, false)
             );
-        } catch (MethodeArticleMarkedDeletedException e) {
-            LOGGER.info("Article {} is marked as deleted.", methodeContent.getUuid());
-            message = messageBuilder.buildMessageForDeletedMethodeContent(
+        } catch (MethodeArticleMarkedDeletedException | MethodeArticleHasNoInternalComponentsException e) {
+            LOGGER.info("Internal components of article {} are missing. " +
+                            "Message with deleted internal components event is created.",
+                    methodeContent.getUuid());
+            message = messageBuilder.buildDeletedInternalComponentsMessage(
                     methodeContent.getUuid(), transactionId, messageTimestamp
             );
         }

--- a/src/main/java/com/ft/methodearticleinternalcomponentsmapper/resources/MapResource.java
+++ b/src/main/java/com/ft/methodearticleinternalcomponentsmapper/resources/MapResource.java
@@ -64,6 +64,8 @@ public class MapResource {
             throw new WebApplicationException(HttpStatus.SC_UNPROCESSABLE_ENTITY);
         }
     }
+
+
 }
 
 

--- a/src/test/java/com/ft/methodearticleinternalcomponentsmapper/messaging/MessageBuilderTest.java
+++ b/src/test/java/com/ft/methodearticleinternalcomponentsmapper/messaging/MessageBuilderTest.java
@@ -3,7 +3,6 @@ package com.ft.methodearticleinternalcomponentsmapper.messaging;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ft.content.model.Content;
 import com.ft.messaging.standards.message.v1.Message;
 import com.ft.methodearticleinternalcomponentsmapper.exception.MethodeArticleInternalComponentsMapperException;
 import com.ft.methodearticleinternalcomponentsmapper.model.InternalComponents;
@@ -106,7 +105,7 @@ public class MessageBuilderTest {
         String lastModified = "2016-11-02T07:59:24.715Z";
         Date lastModifiedDate = Date.from(Instant.parse(lastModified));
 
-        Message msg = messageBuilder.buildMessageForDeletedMethodeContent(UUID.toString(), "tid", lastModifiedDate);
+        Message msg = messageBuilder.buildDeletedInternalComponentsMessage(UUID.toString(), "tid", lastModifiedDate);
 
         Map<String, Object> msgContent = objectMapper.reader(Map.class).readValue(msg.getMessageBody());
         assertThat(msgContent.get("contentUri"), equalTo(contentUri.toString()));

--- a/src/test/java/com/ft/methodearticleinternalcomponentsmapper/messaging/MessageProducingInternalComponentsMapperTest.java
+++ b/src/test/java/com/ft/methodearticleinternalcomponentsmapper/messaging/MessageProducingInternalComponentsMapperTest.java
@@ -2,6 +2,7 @@ package com.ft.methodearticleinternalcomponentsmapper.messaging;
 
 import com.ft.messagequeueproducer.MessageProducer;
 import com.ft.messaging.standards.message.v1.Message;
+import com.ft.methodearticleinternalcomponentsmapper.exception.MethodeArticleHasNoInternalComponentsException;
 import com.ft.methodearticleinternalcomponentsmapper.exception.MethodeArticleMarkedDeletedException;
 import com.ft.methodearticleinternalcomponentsmapper.model.EomFile;
 import com.ft.methodearticleinternalcomponentsmapper.model.InternalComponents;
@@ -79,7 +80,22 @@ public class MessageProducingInternalComponentsMapperTest {
         Message deletedContentMsg = mock(Message.class);
 
         when(mapper.map(any(), anyString(), any(), eq(false))).thenThrow(MethodeArticleMarkedDeletedException.class);
-        when(messageBuilder.buildMessageForDeletedMethodeContent(uuid, tid, date)).thenReturn(deletedContentMsg);
+        when(messageBuilder.buildDeletedInternalComponentsMessage(uuid, tid, date)).thenReturn(deletedContentMsg);
+
+        msgProducingArticleMapper.mapInternalComponents(new EomFile.Builder().withUuid(uuid).build(), tid, date);
+
+        verify(producer).send(Collections.singletonList(deletedContentMsg));
+    }
+
+    @Test
+    public void thatMessageWithNoInternalComponentsIsSentToQueue() {
+        String tid = "tid";
+        Date date = new Date();
+        String uuid = UUID.randomUUID().toString();
+        Message deletedContentMsg = mock(Message.class);
+
+        when(mapper.map(any(), anyString(), any(), eq(false))).thenThrow(MethodeArticleHasNoInternalComponentsException.class);
+        when(messageBuilder.buildDeletedInternalComponentsMessage(uuid, tid, date)).thenReturn(deletedContentMsg);
 
         msgProducingArticleMapper.mapInternalComponents(new EomFile.Builder().withUuid(uuid).build(), tid, date);
 


### PR DESCRIPTION
1. In case the article does not have a topper, generate a delete event as previously it might had.
2. Improve this with an http call to the DS API to find out whether it had or no.

-----
After talking about this with @lucas42, we agreed on not making the additional call to the DS API yet (It might introduce some race conditions).