### PR TITLE
Mark as non-resilient, reduce severity

### DIFF
--- a/helm/methode-article-internal-components-mapper/templates/service.yaml
+++ b/helm/methode-article-internal-components-mapper/templates/service.yaml
@@ -10,6 +10,7 @@ metadata:
     app: {{.Values.service.name}}
     visualize: "true" 
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: 8080 

--- a/helm/methode-article-internal-components-mapper/values.yaml
+++ b/helm/methode-article-internal-components-mapper/values.yaml
@@ -9,6 +9,7 @@ service:
   MCPMUrl: "methode-content-placeholder-mapper:8080"
   DocStoreUrl: "document-store-api:8080"
   ConcordanceUrl: "public-concordances-api:8080"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/methode-article-internal-components-mapper

--- a/src/main/java/com/ft/methodearticleinternalcomponentsmapper/MethodeArticleInternalComponentsMapperApplication.java
+++ b/src/main/java/com/ft/methodearticleinternalcomponentsmapper/MethodeArticleInternalComponentsMapperApplication.java
@@ -201,7 +201,7 @@ public class MethodeArticleInternalComponentsMapperApplication extends Applicati
                 docStoreApiConfig.getEndpointConfiguration().getPort(),
                 "/__gtg",
                 docStoreApiConfig.getHostHeader(),
-                1,
+                2,
                 "Internal components of newly published Methode articles will not be available from the InternalContent API.",
                 "https://dewey.ft.com/document-store-api"
         );
@@ -216,7 +216,7 @@ public class MethodeArticleInternalComponentsMapperApplication extends Applicati
                 concordancesApiConfig.getEndpointConfiguration().getPort(),
                 "/__gtg",
                 concordancesApiConfig.getHostHeader(),
-                1,
+                2,
                 "Internal components of newly published Methode articles will not be available from the InternalContent API.",
                 "https://dewey.ft.com/public-concordances-api"
         );
@@ -231,7 +231,7 @@ public class MethodeArticleInternalComponentsMapperApplication extends Applicati
                 methodeArticleMapperConfig.getEndpointConfiguration().getPort(),
                 "/__gtg",
                 methodeArticleMapperConfig.getHostHeader(),
-                1,
+                2,
                 "Internal components of newly published Methode articles will not be available from the InternalContent API",
                 "https://dewey.ft.com/up-maicm.html");
     }
@@ -245,7 +245,7 @@ public class MethodeArticleInternalComponentsMapperApplication extends Applicati
                 methodeContentPlaceholderMapperConfig.getEndpointConfiguration().getPort(),
                 "/__gtg",
                 methodeContentPlaceholderMapperConfig.getHostHeader(),
-                1,
+                2,
                 "Internal components of newly published Methode content placeholders will not be available from the InternalContent API",
                 "https://dewey.ft.com/up-mcpm.html");
     }


### PR DESCRIPTION
- mappers aren't resilient: both pods read from kafka using the same consumer group - this means only one of them is actually receiving the messages; if the pod which isn't receiving the messages stops, that's not problem, but if the pod who is actually receiving the messages stops working, then the other pod will not pick up messages either
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
- reduced the severity from 1 to 2 so any failures in this service will not turn dashing red