### PR TITLE
Fix: Whitespace stripped out between links and parentheses

### DIFF
--- a/src/main/java/com/ft/methodearticleinternalcomponentsmapper/transformation/MethodeLinksBodyProcessor.java
+++ b/src/main/java/com/ft/methodearticleinternalcomponentsmapper/transformation/MethodeLinksBodyProcessor.java
@@ -55,7 +55,7 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
     private static final String STRING_ENDS_WITH_WHITESPACE_REGEX = ".*\\s+$";
     private static final Pattern STRING_ENDS_WITH_WHITESPACE_REGEX_PATTERN = Pattern.compile(STRING_ENDS_WITH_WHITESPACE_REGEX);
     private static final String STRING_STARTS_WITH_WHITESPACE_REGEX = "^\\s+";
-    private static final String STRING_STARTS_WITH_PUNCTUATION_REGEX = "^\\p{Punct}+.*";
+    private static final String STRING_STARTS_WITH_PUNCTUATION_REGEX = "^(\\p{Pc}|\\p{Pd}|\\p{Pe}|\\p{Pf}|\\p{Po})+.*";
     private static final Pattern STRING_STARTS_WITH_PUNCTUATION_REGEX_PATTERN = Pattern.compile(STRING_STARTS_WITH_PUNCTUATION_REGEX);
     private static final String STRING_ENDS_WITH_PUNCTUATION_REGEX = "\\p{Punct}+$";
     private static final Pattern STRING_ENDS_WITH_PUNCTUATION_REGEX_PATTERN = Pattern.compile(STRING_ENDS_WITH_PUNCTUATION_REGEX);

--- a/src/test/java/com/ft/methodearticleinternalcomponentsmapper/transformation/MethodeLinksBodyProcessorTest.java
+++ b/src/test/java/com/ft/methodearticleinternalcomponentsmapper/transformation/MethodeLinksBodyProcessorTest.java
@@ -371,6 +371,19 @@ public class MethodeLinksBodyProcessorTest {
 		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
 
 		assertThat(processedBody, is(identicalXmlTo(expectedBody)));
+    }
+    
+    @Test
+	public void thatWhitespaceNotRemovedWhenParenthesisPunctuation() {
+        when(clientResponse.getStatus()).thenReturn(200);
+        when(documentStoreApiClient.getContentForUuids(anyCollectionOf(String.class), anyString())).thenReturn(Collections.singletonList(new Content(uuid,"Article")));
+
+		String body = "<body><p><a href=\"" + uuid + "\">link text</a>  (some details)</p></body>";
+		String expectedBody = "<body><p><content id=\"" + uuid + "\" type=\"" + MethodeLinksBodyProcessor.BASE_CONTENT_TYPE + "Article\">link text</content> (some details)</p></body>";
+		
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo(expectedBody)));
 	}
 
 	@Test


### PR DESCRIPTION
Financial-Times/upp-ftcom-lovin#46